### PR TITLE
Fix linting issues in CICD pipeline branch

### DIFF
--- a/konveyor/apps/documents/services/chunk_service.py
+++ b/konveyor/apps/documents/services/chunk_service.py
@@ -142,7 +142,7 @@ class ChunkService(AzureService):
         for i in range(0, total_chunks, actual_batch_size):
             batch = chunks[i : i + actual_batch_size]
             self.log_debug(
-                f"Processing batch {i//actual_batch_size + 1} with {len(batch)} chunks"
+                f"Processing batch {i // actual_batch_size + 1} with {len(batch)} chunks"
             )
             yield batch
 

--- a/konveyor/core/azure_adapters/openai/tests/test_integration.py
+++ b/konveyor/core/azure_adapters/openai/tests/test_integration.py
@@ -32,7 +32,7 @@ def test_embedding_generation():
     # Generate embeddings for each test text
     for i, text in enumerate(test_texts):
         try:
-            logger.info(f"Generating embedding for text {i+1} ({len(text)} chars)")
+            logger.info(f"Generating embedding for text {i + 1} ({len(text)} chars)")
 
             # Generate the embedding
             embedding = client.generate_embedding(text)
@@ -43,11 +43,11 @@ def test_embedding_generation():
             )
             logger.info(f"First 5 values: {embedding[:5]}")
             print(
-                f"Text {i+1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
+                f"Text {i + 1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
             )
         except Exception as e:
-            logger.error(f"Failed to generate embedding for text {i+1}: {str(e)}")
-            print(f"Text {i+1}: Failed to generate embedding: {str(e)}")
+            logger.error(f"Failed to generate embedding for text {i + 1}: {str(e)}")
+            print(f"Text {i + 1}: Failed to generate embedding: {str(e)}")
 
 
 def test_completion_generation():
@@ -72,12 +72,12 @@ def test_completion_generation():
     # Generate completions for each message set
     for i, messages in enumerate(test_messages):
         try:
-            logger.info(f"Generating completion for message set {i+1}")
+            logger.info(f"Generating completion for message set {i + 1}")
             completion = client.generate_completion(messages, max_tokens=100)
             logger.info(
                 f"Successfully generated completion with {len(completion)} chars"
             )
-            print(f"\nPrompt {i+1}:")
+            print(f"\nPrompt {i + 1}:")
             print(f"User: {messages[-1]['content']}")
             print(
                 f"AI: {completion[:100]}..."
@@ -86,9 +86,9 @@ def test_completion_generation():
             )
         except Exception as e:
             logger.error(
-                f"Failed to generate completion for message set {i+1}: {str(e)}"
+                f"Failed to generate completion for message set {i + 1}: {str(e)}"
             )
-            print(f"Prompt {i+1}: Failed to generate completion: {str(e)}")
+            print(f"Prompt {i + 1}: Failed to generate completion: {str(e)}")
 
 
 def verify_environment():

--- a/konveyor/core/azure_adapters/tests/test_search_embedding.py
+++ b/konveyor/core/azure_adapters/tests/test_search_embedding.py
@@ -36,7 +36,7 @@ def test_search_service_embedding():
     # Generate embeddings for each test text
     for i, text in enumerate(test_texts):
         try:
-            logger.info(f"Generating embedding for text {i+1} ({len(text)} chars)")
+            logger.info(f"Generating embedding for text {i + 1} ({len(text)} chars)")
 
             # Generate the embedding
             embedding = search_service.generate_embedding(text)
@@ -47,11 +47,11 @@ def test_search_service_embedding():
             )
             logger.info(f"First 5 values: {embedding[:5]}")
             print(
-                f"Text {i+1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
+                f"Text {i + 1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
             )
         except Exception as e:
-            logger.error(f"Failed to generate embedding for text {i+1}: {str(e)}")
-            print(f"Text {i+1}: Failed to generate embedding: {str(e)}")
+            logger.error(f"Failed to generate embedding for text {i + 1}: {str(e)}")
+            print(f"Text {i + 1}: Failed to generate embedding: {str(e)}")
 
 
 def test_custom_client():

--- a/konveyor/settings/__init__.py
+++ b/konveyor/settings/__init__.py
@@ -21,6 +21,5 @@ elif environment == "konveyor.settings.testing":
     from .testing import *  # noqa: F401, F403
 else:
     raise ImportError(
-        'Settings module "%s" not found. Check DJANGO_SETTINGS_MODULE environment variable.'  # noqa: E501
-        % environment
+        f'Settings module "{environment}" not found. Check DJANGO_SETTINGS_MODULE environment variable.'  # noqa: E501
     )

--- a/konveyor/skills/documentation_navigator/DocumentationNavigatorSkill.py
+++ b/konveyor/skills/documentation_navigator/DocumentationNavigatorSkill.py
@@ -489,7 +489,7 @@ class DocumentationNavigatorSkill:
                 "title": title,
                 "content": content,
                 "score": score,
-                "citation": f"[{i+1}] {title}",
+                "citation": f"[{i + 1}] {title}",
                 "metadata": metadata,
             }
 
@@ -542,7 +542,7 @@ class DocumentationNavigatorSkill:
                     content = content[:300] + "..."
 
             # Format the citation as a superscript number
-            citation_mark = f"[{i+1}]"
+            citation_mark = f"[{i + 1}]"
 
             # Add the content with citation
             answer += f"{content} {citation_mark}\n\n"
@@ -554,7 +554,7 @@ class DocumentationNavigatorSkill:
         answer += "**Sources:**\n"
         for i, (title, doc_id) in enumerate(zip(titles, document_ids, strict=False)):
             # Format each citation with number, title, and document ID
-            answer += f"{i+1}. **{title}** (Document ID: `{doc_id}`)\n"
+            answer += f"{i + 1}. **{title}** (Document ID: `{doc_id}`)\n"
 
         return answer
 
@@ -626,7 +626,10 @@ class DocumentationNavigatorSkill:
             blocks.append(
                 {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"*{i+1}. {title}*\n{content}"},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*{i + 1}. {title}*\n{content}",
+                    },
                 }
             )
 
@@ -933,7 +936,7 @@ class DocumentationNavigatorSkill:
                     content = content[:150] + "..."
 
             # Format the result with title, content, and source
-            text += f"{i+1}. {title}\n"
+            text += f"{i + 1}. {title}\n"
             text += f"{content}\n"
             text += f"Source: Document ID: {document_id}\n"
             text += "─────────────────────────────\n\n"

--- a/konveyor/skills/knowledge_analyzer/examples/gap_analyzer_example.py
+++ b/konveyor/skills/knowledge_analyzer/examples/gap_analyzer_example.py
@@ -55,7 +55,7 @@ def main():
 
     print("\n=== Simulating User Questions ===")
     for i, question in enumerate(questions):
-        print(f"\nQuestion {i+1}: {question}")
+        print(f"\nQuestion {i + 1}: {question}")
 
         # Analyze the question
         analysis_json = analyzer.analyze_question(question, user_id)

--- a/tests/real/test_documentation_navigator_real.py
+++ b/tests/real/test_documentation_navigator_real.py
@@ -117,7 +117,7 @@ class RealSearchService:
             formatted_results = []
             for i, result in enumerate(results):
                 # Log the raw result for debugging
-                logger.debug(f"Raw result {i+1}: {result}")
+                logger.debug(f"Raw result {i + 1}: {result}")
 
                 # Extract fields
                 result_id = result.get("id", "")
@@ -151,7 +151,7 @@ class RealSearchService:
 
                 # Log the formatted result
                 logger.debug(
-                    f"Formatted result {i+1}: id={result_id}, document_id={document_id}, score={score}"  # noqa: E501
+                    f"Formatted result {i + 1}: id={result_id}, document_id={document_id}, score={score}"  # noqa: E501
                 )
                 logger.debug(f"Content: {content[:100]}...")
 
@@ -162,7 +162,7 @@ class RealSearchService:
             # Log a summary of the results
             for i, result in enumerate(formatted_results):
                 logger.info(
-                    f"Result {i+1}: id={result['id']}, document_id={result['document_id']}, score={result['@search.score']}"  # noqa: E501
+                    f"Result {i + 1}: id={result['id']}, document_id={result['document_id']}, score={result['@search.score']}"  # noqa: E501
                 )
                 logger.info(f"Title: {result['metadata']['title']}")
                 logger.info(f"Content preview: {result['content'][:100]}...")
@@ -243,7 +243,7 @@ async def test_documentation_navigator():
         # Log detailed search results
         logger.info("Search results details:")
         for i, result in enumerate(search_results["results"]):
-            logger.info(f"Result {i+1}:")
+            logger.info(f"Result {i + 1}:")
             logger.info(f"  Title: {result['title']}")
             logger.info(f"  Content: {result['content'][:150]}...")
             logger.info(f"  Score: {result['score']}")
@@ -274,7 +274,7 @@ async def test_documentation_navigator():
             logger.info(f"Conversation has {len(messages)} messages")
             for i, msg in enumerate(messages):
                 logger.info(
-                    f"Message {i+1}: Type={msg['type']}, Length={len(msg['content'])}"
+                    f"Message {i + 1}: Type={msg['type']}, Length={len(msg['content'])}"
                 )
 
             # Get conversation context
@@ -311,7 +311,7 @@ async def test_documentation_navigator():
             logger.info(f"Conversation now has {len(messages)} messages")
             for i, msg in enumerate(messages):
                 logger.info(
-                    f"Message {i+1}: Type={msg['type']}, Length={len(msg['content'])}"
+                    f"Message {i + 1}: Type={msg['type']}, Length={len(msg['content'])}"
                 )
 
             # Get conversation context
@@ -348,7 +348,7 @@ async def test_documentation_navigator():
             logger.info(f"Conversation now has {len(messages)} messages")
             for i, msg in enumerate(messages):
                 logger.info(
-                    f"Message {i+1}: Type={msg['type']}, Length={len(msg['content'])}"
+                    f"Message {i + 1}: Type={msg['type']}, Length={len(msg['content'])}"
                 )
 
             # Get conversation context


### PR DESCRIPTION
This PR fixes the linting issues in the feat/task-9-cicd-pipeline branch. The main issues were:

1. Pytest decorators with empty parentheses (PT023 and PT001 errors)
2. String formatting using % instead of f-strings (UP031 error)
3. Formatting issues in several files

All linting checks now pass successfully.