### PR TITLE
Fix linting issues in CICD pipeline branch

### DIFF
--- a/konveyor/settings/__init__.py
+++ b/konveyor/settings/__init__.py
@@ -21,6 +21,5 @@ elif environment == "konveyor.settings.testing":
     from .testing import *  # noqa: F401, F403
 else:
     raise ImportError(
-        'Settings module "%s" not found. Check DJANGO_SETTINGS_MODULE environment variable.'  # noqa: E501
-        % environment
+        f'Settings module "{environment}" not found. Check DJANGO_SETTINGS_MODULE environment variable.'  # noqa: E501
     )


### PR DESCRIPTION
This PR fixes the linting issues in the feat/task-9-cicd-pipeline branch. The main issues were:

1. Pytest decorators with empty parentheses (PT023 and PT001 errors)
2. String formatting using % instead of f-strings (UP031 error)
3. Formatting issues in several files

All linting checks now pass successfully.