### PR TITLE
Refactor pytest decorators for consistency

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,5 +1,10 @@
 name: "Code Quality Checks"
 
+permissions:
+  contents: read   # Required for checkout
+  id-token: write  # Required for Azure login
+  actions: read    # Required for workflow calls
+
 on:
   pull_request:
     branches: [ main, dev ]

--- a/.github/workflows/commit-conventions.yml
+++ b/.github/workflows/commit-conventions.yml
@@ -1,5 +1,8 @@
 name: "Branch Naming Enforcement"
 
+permissions:
+  contents: read  # Required for checkout
+
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]

--- a/.github/workflows/complete-pipeline.yml
+++ b/.github/workflows/complete-pipeline.yml
@@ -1,6 +1,9 @@
 name: "Complete CI/CD Pipeline"
 permissions:
-  id-token: write  # Global permission for all jobs
+  id-token: write  # Required for Azure login
+  contents: read   # Required for checkout
+  packages: write  # Required for pushing to GHCR
+  actions: read    # Required for workflow calls
 on:
   pull_request:
     branches: [ main, dev ]
@@ -92,9 +95,6 @@ jobs:
       needs.integration-tests.outputs.success == 'true' &&
       (github.event.inputs.deploy == 'true' || github.ref_type == 'tag' || startsWith(github.ref, 'refs/tags/v'))
     uses: ./.github/workflows/deploy-app.yml
-    permissions:
-      id-token: write
-      contents: read
     with:
       ref: ${{ github.event.inputs.ref || github.ref }}
       environment: ${{ github.event.inputs.environment || 'test' }}
@@ -108,8 +108,6 @@ jobs:
       needs.integration-tests.outputs.success == 'true' &&
       (github.event.inputs.deploy == 'true' || github.ref_type == 'tag' || contains(github.ref, 'infra'))
     uses: ./.github/workflows/infra-deploy.yml
-    permissions:
-      id-token: write
     with:
       ref: ${{ github.event.inputs.ref || github.ref }}
       environment: ${{ github.event.inputs.environment || 'test' }}

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -1,7 +1,9 @@
 name: "Deploy Application to Azure"
 
 permissions:
-  contents: read # Default required for checkout
+  contents: read   # Required for checkout
+  id-token: write  # Required for Azure login
+  packages: write  # Required for pushing to GHCR
 
 on:
   push:

--- a/.github/workflows/infra-deploy.yml
+++ b/.github/workflows/infra-deploy.yml
@@ -1,8 +1,10 @@
 name: "Deploy Infrastructure and Save Variables"
 
 permissions:
-  contents: read
-  id-token: write # Required for GitHub OIDC token authentication
+  contents: read   # Required for checkout
+  id-token: write  # Required for GitHub OIDC token authentication
+  actions: write   # Required for creating GitHub variables
+  packages: read   # Required for pulling from GHCR
 
 on:
   workflow_dispatch:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,11 @@
 name: "Integration Tests"
 
+permissions:
+  contents: read   # Required for checkout
+  id-token: write  # Required for Azure login
+  actions: read    # Required for workflow calls
+  packages: read   # Required for pulling from GHCR
+
 on:
   pull_request:
     branches: [ main, dev ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+    rev: v5.0.0
     hooks:
     -   id: trailing-whitespace
         exclude: "backups/|backups/.*|.cursor/|.cursor/.*|.devcontainer/|.devcontainer/.*|.*.md|.windsurfrules"
@@ -12,7 +12,7 @@ repos:
         exclude: "backups/|backups/.*|.cursor/|.cursor/.*|.devcontainer/|.devcontainer/.*"
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.3
+    rev: v0.11.8
     hooks:
     -   id: ruff
         args: [--fix]
@@ -21,7 +21,7 @@ repos:
         exclude: "backups/|backups/.*|.cursor/|.cursor/.*|.devcontainer/|.devcontainer/.*|.*.md|.windsurfrules"
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.9.0
+    rev: v1.15.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests, types-setuptools, types-pyyaml]

--- a/konveyor/apps/documents/services/chunk_service.py
+++ b/konveyor/apps/documents/services/chunk_service.py
@@ -142,7 +142,7 @@ class ChunkService(AzureService):
         for i in range(0, total_chunks, actual_batch_size):
             batch = chunks[i : i + actual_batch_size]
             self.log_debug(
-                f"Processing batch {i//actual_batch_size + 1} with {len(batch)} chunks"
+                f"Processing batch {i // actual_batch_size + 1} with {len(batch)} chunks"
             )
             yield batch
 

--- a/konveyor/core/azure_adapters/openai/tests/test_integration.py
+++ b/konveyor/core/azure_adapters/openai/tests/test_integration.py
@@ -32,7 +32,7 @@ def test_embedding_generation():
     # Generate embeddings for each test text
     for i, text in enumerate(test_texts):
         try:
-            logger.info(f"Generating embedding for text {i+1} ({len(text)} chars)")
+            logger.info(f"Generating embedding for text {i + 1} ({len(text)} chars)")
 
             # Generate the embedding
             embedding = client.generate_embedding(text)
@@ -43,11 +43,11 @@ def test_embedding_generation():
             )
             logger.info(f"First 5 values: {embedding[:5]}")
             print(
-                f"Text {i+1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
+                f"Text {i + 1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
             )
         except Exception as e:
-            logger.error(f"Failed to generate embedding for text {i+1}: {str(e)}")
-            print(f"Text {i+1}: Failed to generate embedding: {str(e)}")
+            logger.error(f"Failed to generate embedding for text {i + 1}: {str(e)}")
+            print(f"Text {i + 1}: Failed to generate embedding: {str(e)}")
 
 
 def test_completion_generation():
@@ -72,12 +72,12 @@ def test_completion_generation():
     # Generate completions for each message set
     for i, messages in enumerate(test_messages):
         try:
-            logger.info(f"Generating completion for message set {i+1}")
+            logger.info(f"Generating completion for message set {i + 1}")
             completion = client.generate_completion(messages, max_tokens=100)
             logger.info(
                 f"Successfully generated completion with {len(completion)} chars"
             )
-            print(f"\nPrompt {i+1}:")
+            print(f"\nPrompt {i + 1}:")
             print(f"User: {messages[-1]['content']}")
             print(
                 f"AI: {completion[:100]}..."
@@ -86,9 +86,9 @@ def test_completion_generation():
             )
         except Exception as e:
             logger.error(
-                f"Failed to generate completion for message set {i+1}: {str(e)}"
+                f"Failed to generate completion for message set {i + 1}: {str(e)}"
             )
-            print(f"Prompt {i+1}: Failed to generate completion: {str(e)}")
+            print(f"Prompt {i + 1}: Failed to generate completion: {str(e)}")
 
 
 def verify_environment():

--- a/konveyor/core/azure_adapters/tests/test_search_embedding.py
+++ b/konveyor/core/azure_adapters/tests/test_search_embedding.py
@@ -36,7 +36,7 @@ def test_search_service_embedding():
     # Generate embeddings for each test text
     for i, text in enumerate(test_texts):
         try:
-            logger.info(f"Generating embedding for text {i+1} ({len(text)} chars)")
+            logger.info(f"Generating embedding for text {i + 1} ({len(text)} chars)")
 
             # Generate the embedding
             embedding = search_service.generate_embedding(text)
@@ -47,11 +47,11 @@ def test_search_service_embedding():
             )
             logger.info(f"First 5 values: {embedding[:5]}")
             print(
-                f"Text {i+1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
+                f"Text {i + 1}: Successfully generated embedding with {len(embedding)} dimensions"  # noqa: E501
             )
         except Exception as e:
-            logger.error(f"Failed to generate embedding for text {i+1}: {str(e)}")
-            print(f"Text {i+1}: Failed to generate embedding: {str(e)}")
+            logger.error(f"Failed to generate embedding for text {i + 1}: {str(e)}")
+            print(f"Text {i + 1}: Failed to generate embedding: {str(e)}")
 
 
 def test_custom_client():

--- a/konveyor/core/conversation/tests/test_conversation_manager.py
+++ b/konveyor/core/conversation/tests/test_conversation_manager.py
@@ -17,7 +17,7 @@ from konveyor.core.conversation.memory import InMemoryConversationManager
 
 
 # Test the InMemoryConversationManager
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_in_memory_conversation_manager():
     """Test the InMemoryConversationManager."""
     # Create a conversation manager
@@ -127,7 +127,7 @@ async def test_in_memory_conversation_manager():
 
 
 # Test the ConversationManagerFactory
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_conversation_manager_factory():
     """Test the ConversationManagerFactory."""
     # Create a memory conversation manager

--- a/konveyor/skills/documentation_navigator/DocumentationNavigatorSkill.py
+++ b/konveyor/skills/documentation_navigator/DocumentationNavigatorSkill.py
@@ -489,7 +489,7 @@ class DocumentationNavigatorSkill:
                 "title": title,
                 "content": content,
                 "score": score,
-                "citation": f"[{i+1}] {title}",
+                "citation": f"[{i + 1}] {title}",
                 "metadata": metadata,
             }
 
@@ -542,7 +542,7 @@ class DocumentationNavigatorSkill:
                     content = content[:300] + "..."
 
             # Format the citation as a superscript number
-            citation_mark = f"[{i+1}]"
+            citation_mark = f"[{i + 1}]"
 
             # Add the content with citation
             answer += f"{content} {citation_mark}\n\n"
@@ -554,7 +554,7 @@ class DocumentationNavigatorSkill:
         answer += "**Sources:**\n"
         for i, (title, doc_id) in enumerate(zip(titles, document_ids, strict=False)):
             # Format each citation with number, title, and document ID
-            answer += f"{i+1}. **{title}** (Document ID: `{doc_id}`)\n"
+            answer += f"{i + 1}. **{title}** (Document ID: `{doc_id}`)\n"
 
         return answer
 
@@ -626,7 +626,10 @@ class DocumentationNavigatorSkill:
             blocks.append(
                 {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": f"*{i+1}. {title}*\n{content}"},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": f"*{i + 1}. {title}*\n{content}",
+                    },
                 }
             )
 
@@ -933,7 +936,7 @@ class DocumentationNavigatorSkill:
                     content = content[:150] + "..."
 
             # Format the result with title, content, and source
-            text += f"{i+1}. {title}\n"
+            text += f"{i + 1}. {title}\n"
             text += f"{content}\n"
             text += f"Source: Document ID: {document_id}\n"
             text += "─────────────────────────────\n\n"

--- a/konveyor/skills/knowledge_analyzer/examples/gap_analyzer_example.py
+++ b/konveyor/skills/knowledge_analyzer/examples/gap_analyzer_example.py
@@ -55,7 +55,7 @@ def main():
 
     print("\n=== Simulating User Questions ===")
     for i, question in enumerate(questions):
-        print(f"\nQuestion {i+1}: {question}")
+        print(f"\nQuestion {i + 1}: {question}")
 
         # Analyze the question
         analysis_json = analyzer.analyze_question(question, user_id)

--- a/scripts/rename_updated_files.py
+++ b/scripts/rename_updated_files.py
@@ -29,7 +29,7 @@ def rename_files():
 
     # Create a backup directory
     backup_dir = (
-        project_root / "backups" / f'backup_{datetime.now().strftime("%Y%m%d_%H%M%S")}'
+        project_root / "backups" / f"backup_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
     )
     backup_dir.mkdir(parents=True, exist_ok=True)
     logger.info(f"Created backup directory: {backup_dir}")

--- a/scripts/verify_user_profile_integration.py
+++ b/scripts/verify_user_profile_integration.py
@@ -64,13 +64,13 @@ def verify_user_profiles():
 
     logger.info("Profile statistics:")
     logger.info(
-        f"  Profiles with email: {stats['with_email']} ({stats['with_email']/profile_count*100:.1f}%)"
+        f"  Profiles with email: {stats['with_email']} ({stats['with_email'] / profile_count * 100:.1f}%)"
     )
     logger.info(
-        f"  Profiles with code language preference: {stats['with_code_language']} ({stats['with_code_language']/profile_count*100:.1f}%)"
+        f"  Profiles with code language preference: {stats['with_code_language']} ({stats['with_code_language'] / profile_count * 100:.1f}%)"
     )
     logger.info(
-        f"  Profiles with response format preference: {stats['with_response_format']} ({stats['with_response_format']/profile_count*100:.1f}%)"
+        f"  Profiles with response format preference: {stats['with_response_format']} ({stats['with_response_format'] / profile_count * 100:.1f}%)"
     )
     logger.info(f"  Average interactions per profile: {stats['avg_interactions']:.1f}")
     logger.info(f"  Maximum interactions for a profile: {stats['max_interactions']}")

--- a/tests/apps/bot/test_conversation_context.py
+++ b/tests/apps/bot/test_conversation_context.py
@@ -12,7 +12,7 @@ from django.test import RequestFactory
 from konveyor.apps.bot.views import process_message, slack_webhook
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_conversation_context_management():
     """Test that conversation context is correctly managed."""
     # Create a request factory

--- a/tests/apps/bot/test_error_handling.py
+++ b/tests/apps/bot/test_error_handling.py
@@ -12,7 +12,7 @@ from django.test import RequestFactory
 from konveyor.apps.bot.views import process_message, slack_webhook  # noqa: F401
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_error_handling_specific_errors():
     """Test that specific error types are handled correctly."""
     # Create a request factory
@@ -69,7 +69,7 @@ def test_error_handling_specific_errors():
         )  # text
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_error_handling_slack_api_errors():
     """Test that Slack API errors are handled correctly."""
     # Create a request factory
@@ -128,7 +128,7 @@ def test_error_handling_slack_api_errors():
         assert mock_slack_service.send_direct_message.call_count == 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_error_handling_graceful_recovery():
     """Test that the system recovers gracefully from errors."""
     # Create a request factory

--- a/tests/apps/bot/test_error_handling.py
+++ b/tests/apps/bot/test_error_handling.py
@@ -3,7 +3,7 @@ Tests for improved error handling in the Slack webhook handler.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401, F401
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401
 
 import pytest
 from django.http import HttpResponse, JsonResponse  # noqa: F401

--- a/tests/apps/bot/test_slack_user_profile_service.py
+++ b/tests/apps/bot/test_slack_user_profile_service.py
@@ -13,7 +13,7 @@ from konveyor.apps.bot.services.slack_user_profile_service import (
 )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_get_or_create_profile_existing():
     """Test getting an existing profile."""
     # Create a test profile
@@ -45,7 +45,7 @@ def test_get_or_create_profile_existing():
     mock_slack_service.client.users_info.assert_not_called()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_get_or_create_profile_new():
     """Test creating a new profile."""
     # Mock the Slack service
@@ -84,7 +84,7 @@ def test_get_or_create_profile_new():
     mock_slack_service.client.users_info.assert_called_once_with(user="new_user")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_update_profile():
     """Test updating a profile."""
     # Create a test profile
@@ -127,7 +127,7 @@ def test_update_profile():
     mock_slack_service.client.users_info.assert_called_once_with(user="test_user")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_update_preference():
     """Test updating a user preference."""
     # Create a test profile
@@ -167,7 +167,7 @@ def test_update_preference():
     assert result.response_format_preference == "detailed"
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_get_active_profiles():
     """Test getting active profiles."""
     # Create test profiles

--- a/tests/apps/bot/test_slash_commands.py
+++ b/tests/apps/bot/test_slash_commands.py
@@ -149,7 +149,7 @@ def test_code_command():
     assert len(context_blocks) >= 1
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_preferences_command():
     """Test the preferences command handler."""
     # Mock the SlackUserProfileService
@@ -203,7 +203,7 @@ def test_preferences_command():
         )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_profile_command():
     """Test the profile command handler."""
     # Mock the SlackUserProfileService
@@ -244,7 +244,7 @@ def test_profile_command():
         mock_service.get_or_create_profile.assert_called_once_with("test_user")
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_slash_command_endpoint():
     """Test the slash command endpoint."""
     # Create a request factory
@@ -301,7 +301,7 @@ def test_slash_command_endpoint():
         )
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_slash_command_unknown_command():
     """Test the slash command endpoint with an unknown command."""
     # Create a request factory

--- a/tests/apps/bot/test_thread_support.py
+++ b/tests/apps/bot/test_thread_support.py
@@ -12,7 +12,7 @@ from django.test import RequestFactory
 from konveyor.apps.bot.views import process_message, slack_webhook
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_thread_support():
     """Test that thread_ts is correctly extracted and used."""
     # Create a request factory

--- a/tests/apps/bot/test_views_integration.py
+++ b/tests/apps/bot/test_views_integration.py
@@ -60,7 +60,7 @@ def test_root_handler():
 
 
 # Test the slack_webhook function
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_slack_webhook():
     """Test the slack_webhook function."""
     # Create a request factory

--- a/tests/apps/bot/test_views_integration.py
+++ b/tests/apps/bot/test_views_integration.py
@@ -6,7 +6,7 @@ verifying that they work correctly with the new core components.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401, F401
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401
 
 import pytest
 from django.http import HttpResponse, JsonResponse

--- a/tests/apps/rag/test_views_integration.py
+++ b/tests/apps/rag/test_views_integration.py
@@ -17,7 +17,7 @@ from konveyor.apps.rag.views_updated import ConversationViewSet
 
 
 # Test the ConversationViewSet
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_conversation_viewset():
     """Test the ConversationViewSet."""
     # Create a request factory

--- a/tests/core/chat/test_chat_skill_integration.py
+++ b/tests/core/chat/test_chat_skill_integration.py
@@ -6,7 +6,7 @@ verifying that it works correctly with the new core components.
 """
 
 import asyncio
-from typing import Any, Dict, List  # noqa: F401, F401, F401
+from typing import Any, Dict, List  # noqa: F401
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/core/chat/test_chat_skill_integration.py
+++ b/tests/core/chat/test_chat_skill_integration.py
@@ -15,7 +15,7 @@ from konveyor.core.chat.skill_updated import ChatSkill
 
 
 # Test the ChatSkill with mocked dependencies
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_chat_skill_integration():
     """Test the ChatSkill integration with the new core components."""
     # Create a mock kernel

--- a/tests/core/conversation/test_conversation_manager.py
+++ b/tests/core/conversation/test_conversation_manager.py
@@ -7,7 +7,7 @@ including the InMemoryConversationManager and the ConversationManagerFactory.
 
 import asyncio
 import os  # noqa: F401
-from typing import Any, Dict, List  # noqa: F401, F401, F401
+from typing import Any, Dict, List  # noqa: F401
 
 import pytest
 

--- a/tests/core/conversation/test_conversation_manager.py
+++ b/tests/core/conversation/test_conversation_manager.py
@@ -17,7 +17,7 @@ from konveyor.core.conversation.memory import InMemoryConversationManager
 
 
 # Test the InMemoryConversationManager
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_in_memory_conversation_manager():
     """Test the InMemoryConversationManager."""
     # Create a conversation manager
@@ -127,7 +127,7 @@ async def test_in_memory_conversation_manager():
 
 
 # Test the ConversationManagerFactory
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_conversation_manager_factory():
     """Test the ConversationManagerFactory."""
     # Create a memory conversation manager

--- a/tests/core/generation/test_response_generator.py
+++ b/tests/core/generation/test_response_generator.py
@@ -6,8 +6,8 @@ including the ResponseGenerator and ResponseGeneratorFactory.
 """
 
 import asyncio
-from typing import Any, Dict, List  # noqa: F401, F401, F401
-from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401, F401, F401
+from typing import Any, Dict, List  # noqa: F401
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401
 
 import pytest
 

--- a/tests/core/generation/test_response_generator.py
+++ b/tests/core/generation/test_response_generator.py
@@ -71,7 +71,7 @@ class MockConversationManager:
 
 
 # Test the ResponseGenerator
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_response_generator():
     """Test the ResponseGenerator."""
     # Create mock dependencies

--- a/tests/core/rag/test_rag_service_integration.py
+++ b/tests/core/rag/test_rag_service_integration.py
@@ -6,7 +6,7 @@ verifying that it works correctly with the new core components.
 """
 
 import asyncio
-from typing import Any, Dict, List  # noqa: F401, F401, F401
+from typing import Any, Dict, List  # noqa: F401
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest

--- a/tests/core/rag/test_rag_service_integration.py
+++ b/tests/core/rag/test_rag_service_integration.py
@@ -15,7 +15,7 @@ from konveyor.core.rag.rag_service_updated import RAGService
 
 
 # Test the RAG service with mocked dependencies
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_rag_service_integration():
     """Test the RAG service integration with the new core components."""
     # Create a mock client manager

--- a/tests/core/skills/test_agent_orchestrator_mock.py
+++ b/tests/core/skills/test_agent_orchestrator_mock.py
@@ -18,7 +18,7 @@ from konveyor.core.agent import AgentOrchestratorSkill, SkillRegistry
 from konveyor.core.chat import ChatSkill
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_kernel():
     """Mock Kernel for testing."""
     kernel = MagicMock(spec=Kernel)
@@ -76,19 +76,19 @@ def mock_kernel():
     return kernel
 
 
-@pytest.fixture()
+@pytest.fixture
 def registry():
     """Create a SkillRegistry for testing."""
     return SkillRegistry()
 
 
-@pytest.fixture()
+@pytest.fixture
 def chat_skill():
     """Create a ChatSkill for testing."""
     return ChatSkill()
 
 
-@pytest.fixture()
+@pytest.fixture
 def orchestrator(mock_kernel, registry, chat_skill):
     """Create an AgentOrchestratorSkill for testing."""
     orchestrator = AgentOrchestratorSkill(mock_kernel, registry)
@@ -101,7 +101,7 @@ def orchestrator(mock_kernel, registry, chat_skill):
     return orchestrator
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_chat(orchestrator, mock_kernel):
     """Test processing a chat request."""
     # Process a chat request
@@ -124,7 +124,7 @@ async def test_process_request_with_chat(orchestrator, mock_kernel):
     assert result["success"] is True
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_question(orchestrator, mock_kernel):
     """Test processing a question request."""
     # Process a question request
@@ -140,7 +140,7 @@ async def test_process_request_with_question(orchestrator, mock_kernel):
     assert result["success"] is True
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_greeting(orchestrator, mock_kernel):
     """Test processing a greeting request."""
     # Process a greeting request
@@ -156,7 +156,7 @@ async def test_process_request_with_greeting(orchestrator, mock_kernel):
     assert result["success"] is True
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_formatting(orchestrator, mock_kernel):
     """Test processing a formatting request."""
     # Process a formatting request
@@ -172,7 +172,7 @@ async def test_process_request_with_formatting(orchestrator, mock_kernel):
     assert result["success"] is True
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_empty_request(orchestrator):
     """Test processing an empty request."""
     # Process an empty request
@@ -188,7 +188,7 @@ async def test_process_request_with_empty_request(orchestrator):
     assert result["success"] is False
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_error(orchestrator, mock_kernel):
     """Test processing a request that causes an error."""
     # Make the kernel.invoke method raise an exception

--- a/tests/core/skills/test_agent_orchestrator_real.py
+++ b/tests/core/skills/test_agent_orchestrator_real.py
@@ -45,7 +45,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def real_kernel():
     """Create a real Kernel with Azure OpenAI for testing."""
     try:
@@ -56,19 +56,19 @@ def real_kernel():
         pytest.skip(f"Failed to create kernel: {str(e)}")
 
 
-@pytest.fixture()
+@pytest.fixture
 def registry():
     """Create a SkillRegistry for testing."""
     return SkillRegistry()
 
 
-@pytest.fixture()
+@pytest.fixture
 def chat_skill():
     """Create a ChatSkill for testing."""
     return ChatSkill()
 
 
-@pytest.fixture()
+@pytest.fixture
 def orchestrator(real_kernel, registry, chat_skill):
     """Create an AgentOrchestratorSkill for testing."""
     orchestrator = AgentOrchestratorSkill(real_kernel, registry)
@@ -81,7 +81,7 @@ def orchestrator(real_kernel, registry, chat_skill):
     return orchestrator
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_chat(orchestrator):
     """Test processing a chat request with real Azure OpenAI."""
     # Process a chat request
@@ -100,7 +100,7 @@ async def test_process_request_with_chat(orchestrator):
     assert "success" in result
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_question(orchestrator):
     """Test processing a question request with real Azure OpenAI."""
     # Process a question request
@@ -120,7 +120,7 @@ async def test_process_request_with_question(orchestrator):
     assert "success" in result
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_process_request_with_empty_request(orchestrator):
     """Test processing an empty request with real Azure OpenAI."""
     # Process an empty request

--- a/tests/core/skills/test_setup.py
+++ b/tests/core/skills/test_setup.py
@@ -10,13 +10,13 @@ from konveyor.core.kernel import create_kernel
 config = AzureConfig()
 
 
-@pytest.mark.integration()
+@pytest.mark.integration
 @pytest.mark.skipif(
     not config.get_setting("AZURE_OPENAI_ENDPOINT")
     or not config.get_setting("AZURE_OPENAI_API_KEY"),
     reason="Azure OpenAI environment not configured",
 )
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_create_kernel_services_real():
     """
     Robust integration test for Semantic Kernel with Azure OpenAI.

--- a/tests/integration/test_agent_orchestration_mock.py
+++ b/tests/integration/test_agent_orchestration_mock.py
@@ -35,7 +35,7 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_turn_context():
     """Create a mock TurnContext for testing."""
     context = MagicMock(spec=TurnContext)
@@ -56,7 +56,7 @@ def mock_turn_context():
     return context
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_kernel():
     """Mock Kernel for testing."""
     # Create a simple mock kernel
@@ -106,7 +106,7 @@ def mock_kernel():
     return kernel
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_initialization(mock_kernel):
     """Test that the bot initializes correctly."""
     # Patch the create_kernel function to avoid validation errors
@@ -121,7 +121,7 @@ async def test_bot_initialization(mock_kernel):
         assert hasattr(bot, "conversations")
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_message_handling(mock_kernel, mock_turn_context):
     """Test that the bot handles messages correctly."""
     # Patch the create_kernel function to avoid validation errors
@@ -157,7 +157,7 @@ async def test_bot_message_handling(mock_kernel, mock_turn_context):
         assert activity.text == "Test response"
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_error_handling(mock_kernel, mock_turn_context):
     """Test that the bot handles errors correctly."""
     # Patch the create_kernel function to avoid validation errors
@@ -186,7 +186,7 @@ async def test_bot_error_handling(mock_kernel, mock_turn_context):
         assert "Test error" in activity.text
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_conversation_state(mock_kernel, mock_turn_context):
     """Test that the bot maintains conversation state."""
     # Patch the create_kernel function to avoid validation errors
@@ -217,7 +217,7 @@ async def test_bot_conversation_state(mock_kernel, mock_turn_context):
         )
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_members_added(mock_kernel):
     """Test that the bot handles new members correctly."""
     # Patch the create_kernel function to avoid validation errors

--- a/tests/integration/test_agent_orchestration_real.py
+++ b/tests/integration/test_agent_orchestration_real.py
@@ -59,7 +59,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_turn_context():
     """Create a mock TurnContext for testing."""
     context = MagicMock(spec=TurnContext)
@@ -80,7 +80,7 @@ def mock_turn_context():
     return context
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_initialization():
     """Test that the bot initializes correctly with real Azure OpenAI."""
     try:
@@ -97,7 +97,7 @@ async def test_bot_initialization():
         pytest.fail(f"Bot initialization failed: {str(e)}")
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_message_handling(mock_turn_context):
     """Test that the bot handles messages correctly with real Azure OpenAI."""
     try:
@@ -122,7 +122,7 @@ async def test_bot_message_handling(mock_turn_context):
         pytest.fail(f"Message handling failed: {str(e)}")
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_bot_members_added():
     """Test that the bot handles new members correctly with real Azure OpenAI."""
     try:

--- a/tests/integration/test_rag_e2e.py
+++ b/tests/integration/test_rag_e2e.py
@@ -31,7 +31,7 @@ from konveyor.core.azure_utils.clients import AzureClientManager  # noqa: E402
 from konveyor.core.rag.rag_service import RAGService  # noqa: E402
 
 
-@pytest.mark.integration()
+@pytest.mark.integration
 class TestRAGIntegration:
     """End-to-end tests for RAG functionality using real Azure services"""
 
@@ -84,7 +84,7 @@ class TestRAGIntegration:
         self.storage_manager.mongo_client.close()
         await self.storage_manager.redis_client.aclose()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_kubernetes_basic_concepts(self):
         """Test RAG with basic Kubernetes concepts"""
         queries = [
@@ -110,7 +110,7 @@ class TestRAGIntegration:
             assert len(messages) > 0
             assert any(m["content"] == query for m in messages)
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_linux_kernel_concepts(self):
         """Test RAG with Linux kernel concepts"""
         queries = [
@@ -128,7 +128,7 @@ class TestRAGIntegration:
             assert len(response["sources"]) >= 1
             assert all("linux" in s["source"].lower() for s in response["sources"])
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_container_runtime_interaction(self):
         """Test RAG with questions about container runtime and kernel interaction"""
         query = "How do Kubernetes containers interact with the Linux kernel?"
@@ -144,7 +144,7 @@ class TestRAGIntegration:
         assert "container" in response["answer"].lower()
         assert "kernel" in response["answer"].lower()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_code_example_generation(self):
         """Test RAG's ability to provide code examples"""
         queries = [
@@ -167,7 +167,7 @@ class TestRAGIntegration:
             if "linux" in query.lower():
                 assert "#include" in response["answer"]
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_conversation_context(self):
         """Test RAG's ability to maintain context in a conversation"""
         queries = [

--- a/tests/integration/test_slack_bot.py
+++ b/tests/integration/test_slack_bot.py
@@ -15,7 +15,7 @@ async def dummy_process_activity(activity, auth_header, handler):
     return DummyResponse(body={"type": "message", "text": "Hello"}, status=200)
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_slack_messages_returns_200(monkeypatch):
     # Monkeypatch the Adapter to avoid real processing
     monkeypatch.setattr(ADAPTER, "process_activity", dummy_process_activity)
@@ -34,13 +34,13 @@ async def test_slack_messages_returns_200(monkeypatch):
     assert resp.status == 200
 
 
-@pytest.fixture()
+@pytest.fixture
 async def client(aiohttp_client):
     """A test client for the Bot HTTP endpoint."""
     return await aiohttp_client(APP)
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_slack_http_returns_200(client, monkeypatch):
     # Monkeypatch the Adapter.process_activity
     monkeypatch.setattr(ADAPTER, "process_activity", dummy_process_activity)

--- a/tests/integration/test_slack_e2e.py
+++ b/tests/integration/test_slack_e2e.py
@@ -11,7 +11,7 @@ load_dotenv()
 
 
 # Integration test for real Slack Bot via ngrok
-@pytest.mark.integration()
+@pytest.mark.integration
 def test_slack_e2e():
     # Load environment
     ngrok_url = os.getenv("NGROK_URL")

--- a/tests/real/test_documentation_navigator_real.py
+++ b/tests/real/test_documentation_navigator_real.py
@@ -117,7 +117,7 @@ class RealSearchService:
             formatted_results = []
             for i, result in enumerate(results):
                 # Log the raw result for debugging
-                logger.debug(f"Raw result {i+1}: {result}")
+                logger.debug(f"Raw result {i + 1}: {result}")
 
                 # Extract fields
                 result_id = result.get("id", "")
@@ -151,7 +151,7 @@ class RealSearchService:
 
                 # Log the formatted result
                 logger.debug(
-                    f"Formatted result {i+1}: id={result_id}, document_id={document_id}, score={score}"  # noqa: E501
+                    f"Formatted result {i + 1}: id={result_id}, document_id={document_id}, score={score}"  # noqa: E501
                 )
                 logger.debug(f"Content: {content[:100]}...")
 
@@ -162,7 +162,7 @@ class RealSearchService:
             # Log a summary of the results
             for i, result in enumerate(formatted_results):
                 logger.info(
-                    f"Result {i+1}: id={result['id']}, document_id={result['document_id']}, score={result['@search.score']}"  # noqa: E501
+                    f"Result {i + 1}: id={result['id']}, document_id={result['document_id']}, score={result['@search.score']}"  # noqa: E501
                 )
                 logger.info(f"Title: {result['metadata']['title']}")
                 logger.info(f"Content preview: {result['content'][:100]}...")
@@ -243,7 +243,7 @@ async def test_documentation_navigator():
         # Log detailed search results
         logger.info("Search results details:")
         for i, result in enumerate(search_results["results"]):
-            logger.info(f"Result {i+1}:")
+            logger.info(f"Result {i + 1}:")
             logger.info(f"  Title: {result['title']}")
             logger.info(f"  Content: {result['content'][:150]}...")
             logger.info(f"  Score: {result['score']}")
@@ -274,7 +274,7 @@ async def test_documentation_navigator():
             logger.info(f"Conversation has {len(messages)} messages")
             for i, msg in enumerate(messages):
                 logger.info(
-                    f"Message {i+1}: Type={msg['type']}, Length={len(msg['content'])}"
+                    f"Message {i + 1}: Type={msg['type']}, Length={len(msg['content'])}"
                 )
 
             # Get conversation context
@@ -311,7 +311,7 @@ async def test_documentation_navigator():
             logger.info(f"Conversation now has {len(messages)} messages")
             for i, msg in enumerate(messages):
                 logger.info(
-                    f"Message {i+1}: Type={msg['type']}, Length={len(msg['content'])}"
+                    f"Message {i + 1}: Type={msg['type']}, Length={len(msg['content'])}"
                 )
 
             # Get conversation context
@@ -348,7 +348,7 @@ async def test_documentation_navigator():
             logger.info(f"Conversation now has {len(messages)} messages")
             for i, msg in enumerate(messages):
                 logger.info(
-                    f"Message {i+1}: Type={msg['type']}, Length={len(msg['content'])}"
+                    f"Message {i + 1}: Type={msg['type']}, Length={len(msg['content'])}"
                 )
 
             # Get conversation context

--- a/tests/services/rag/test_context_service.py
+++ b/tests/services/rag/test_context_service.py
@@ -65,9 +65,9 @@ async def test_retrieve_context_integration(context_service, client_manager):
     # Retrieve context via service
     results = await context_service.retrieve_context(content)
     # Verify that our test document is returned
-    assert any(
-        r["content"] == content for r in results
-    ), f"Expected document content in results: {results}"
+    assert any(r["content"] == content for r in results), (
+        f"Expected document content in results: {results}"
+    )
     assert all(r["relevance_score"] >= 0.3 for r in results)
 
     # Cleanup: delete test document from index

--- a/tests/services/rag/test_context_service.py
+++ b/tests/services/rag/test_context_service.py
@@ -31,8 +31,8 @@ async def context_service(client_manager):
     return ContextService(client_manager)
 
 
-@pytest.mark.integration()
-@pytest.mark.asyncio()
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_retrieve_context_integration(context_service, client_manager):
     """
     Indexes a test document and retrieves it via ContextService.retrieve_context

--- a/tests/services/rag/test_rag_api.py
+++ b/tests/services/rag/test_rag_api.py
@@ -9,8 +9,8 @@ async def api_client():
     return AsyncClient()
 
 
-@pytest.mark.integration()
-@pytest.mark.asyncio()
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_create_conversation(api_client):
     """Test creating a new conversation via API"""
     response = await api_client.post("/api/rag/conversations/")
@@ -19,8 +19,8 @@ async def test_create_conversation(api_client):
     assert "id" in data, f"Unexpected response payload: {data}"
 
 
-@pytest.mark.integration()
-@pytest.mark.asyncio()
+@pytest.mark.integration
+@pytest.mark.asyncio
 async def test_ask_and_history(api_client):
     """Test asking a question and retrieving conversation history"""
     # Create conversation

--- a/tests/services/rag/test_rag_service.py
+++ b/tests/services/rag/test_rag_service.py
@@ -7,7 +7,7 @@ from konveyor.core.rag.context_service import ContextService
 from konveyor.core.rag.rag_service import RAGService
 
 
-@pytest.fixture()
+@pytest.fixture
 async def rag_service():
     context_service = AsyncMock(spec=ContextService)
     storage_manager = AsyncMock(spec=AzureClientManager)
@@ -16,7 +16,7 @@ async def rag_service():
     return service
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_generate_response_kubernetes_concepts(rag_service):
     """Test response generation for Kubernetes conceptual questions"""
     # Mock context retrieval
@@ -47,7 +47,7 @@ async def test_generate_response_kubernetes_concepts(rag_service):
     assert response["sources"][0]["source"].endswith("pod-overview.md")
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_generate_response_linux_kernel(rag_service):
     """Test response generation for Linux kernel questions"""
     rag_service.context_service.retrieve_context.return_value = [
@@ -72,7 +72,7 @@ async def test_generate_response_linux_kernel(rag_service):
     assert response["sources"][0]["source"].endswith("syscalls.rst")
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_generate_response_with_code_examples(rag_service):
     """Test response generation with code examples"""
     rag_service.context_service.retrieve_context.return_value = [
@@ -101,7 +101,7 @@ async def test_generate_response_with_code_examples(rag_service):
     assert response["sources"][0]["source"].endswith("pod-yaml.md")
 
 
-@pytest.mark.asyncio()
+@pytest.mark.asyncio
 async def test_generate_response_with_multiple_sources(rag_service):
     """Test response generation combining multiple documentation sources"""
     rag_service.context_service.retrieve_context.return_value = [

--- a/tests/test_chat_skill.py
+++ b/tests/test_chat_skill.py
@@ -21,7 +21,7 @@ IN_CI = os.environ.get("CI") == "true"
 HAS_AZURE_CREDENTIALS = bool(os.environ.get("AZURE_OPENAI_ENDPOINT"))
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_kernel():
     """Mock Kernel for testing when real credentials aren't available."""
     with patch("konveyor.core.kernel.factory.Kernel") as mock_kernel_class:
@@ -85,7 +85,7 @@ def mock_kernel():
         yield kernel_instance
 
 
-@pytest.fixture()
+@pytest.fixture
 def real_or_mock_kernel(mock_kernel):
     """
     Return a real kernel if Azure credentials are available,
@@ -202,7 +202,7 @@ def test_chat_skill_format_as_bullet_list(real_or_mock_kernel):
     assert len(result.strip().split("\n")) == 3
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_azure_client_manager():
     """Mock AzureClientManager for testing."""
     with patch("konveyor.core.kernel.factory.AzureClientManager") as mock_manager:
@@ -216,7 +216,7 @@ def mock_azure_client_manager():
         yield mock_manager
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_azure_chat_completion():
     """Mock AzureChatCompletion for testing."""
     with patch("konveyor.core.kernel.factory.AzureChatCompletion") as mock_chat:
@@ -225,7 +225,7 @@ def mock_azure_chat_completion():
         yield mock_chat
 
 
-@pytest.fixture()
+@pytest.fixture
 def mock_volatile_memory_store():
     """Mock VolatileMemoryStore for testing."""
     with patch("konveyor.core.kernel.factory.VolatileMemoryStore") as mock_store:

--- a/tests/test_documentation_navigator_integration.py
+++ b/tests/test_documentation_navigator_integration.py
@@ -11,7 +11,7 @@ To run these tests, use:
 
 import asyncio  # noqa: F401
 import os
-from typing import Any, Dict, List, Optional  # noqa: F401, F401, F401, F401
+from typing import Any, Dict, List, Optional  # noqa: F401
 
 import pytest
 

--- a/tests/test_documentation_navigator_integration.py
+++ b/tests/test_documentation_navigator_integration.py
@@ -26,17 +26,17 @@ from konveyor.skills.documentation_navigator import (  # noqa: E402, E501
 from konveyor.skills.setup import create_kernel  # noqa: E402
 
 
-@pytest.mark.integration()
+@pytest.mark.integration
 class TestDocumentationNavigatorIntegration:
     """Integration tests for the DocumentationNavigatorSkill."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def skill(self):
         """Create a DocumentationNavigatorSkill instance for testing."""
         kernel = create_kernel()
         return DocumentationNavigatorSkill(kernel)
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_search_documentation(self, skill):
         """Test searching documentation with the real SearchService."""
         # Skip if SKIP_INTEGRATION_TESTS is set
@@ -63,7 +63,7 @@ class TestDocumentationNavigatorIntegration:
                 assert "title" in result
                 assert "document_id" in result
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_answer_question_with_conversation(self, skill):
         """Test answering a question with conversation context using the real SearchService."""  # noqa: E501
         # Skip if SKIP_INTEGRATION_TESTS is set
@@ -90,7 +90,7 @@ class TestDocumentationNavigatorIntegration:
         assert follow_up_answer
         assert len(follow_up_answer) > 0
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_format_for_slack(self, skill):
         """Test formatting search results for Slack using the real SearchService."""
         # Skip if SKIP_INTEGRATION_TESTS is set

--- a/tests/test_documentation_navigator_memory.py
+++ b/tests/test_documentation_navigator_memory.py
@@ -222,12 +222,12 @@ sys.modules[
 class TestDocumentationNavigatorMemory:
     """Tests for the DocumentationNavigatorSkill with conversation memory."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def skill(self):
         """Create a DocumentationNavigatorSkill instance for testing."""
         return DocumentationNavigatorSkill()
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_create_conversation(self, skill):
         """Test creating a new conversation."""
         # Create a conversation
@@ -238,7 +238,7 @@ class TestDocumentationNavigatorMemory:
         assert conversation["user_id"] == "test-user"
         assert "created_at" in conversation
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_answer_question_with_conversation(self, skill):
         """Test answering a question with conversation context."""
         # Create a conversation
@@ -265,7 +265,7 @@ class TestDocumentationNavigatorMemory:
         assert messages[1]["type"] == "assistant"
         assert "What is the onboarding process?" in messages[0]["content"]
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_continue_conversation(self, skill):
         """Test continuing a conversation with follow-up questions."""
         # Create a conversation
@@ -322,7 +322,7 @@ class TestDocumentationNavigatorMemory:
         assert messages[5]["type"] == "assistant"
         assert "Who can help me with IT setup?" in messages[4]["content"]
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_format_for_slack_with_conversation(self, skill):
         """Test formatting search results for Slack with conversation context."""
         # Create a conversation
@@ -349,7 +349,7 @@ class TestDocumentationNavigatorMemory:
         assert messages[1]["type"] == "assistant"
         assert "company policies" in messages[0]["content"]
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_query_enhancement_with_context(self, skill):
         """Test query enhancement based on conversation context."""
         # Create a conversation

--- a/tests/test_documentation_navigator_skill.py
+++ b/tests/test_documentation_navigator_skill.py
@@ -179,7 +179,7 @@ def mock_create_kernel():
 class TestDocumentationNavigatorSkill:
     """Tests for the DocumentationNavigatorSkill."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def skill(self):
         """Create a DocumentationNavigatorSkill with a mock SearchService."""
         # The SearchService is already mocked at the module level
@@ -192,7 +192,7 @@ class TestDocumentationNavigatorSkill:
         assert skill is not None
         assert hasattr(skill, "search_service")
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_search_documentation(self, skill):
         """Test the search_documentation function."""
         # Call the function
@@ -211,7 +211,7 @@ class TestDocumentationNavigatorSkill:
         assert result["success"] is True
         assert len(result["results"]) == 2
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_answer_question(self, skill):
         """Test the answer_question function."""
         # Call the function
@@ -221,7 +221,7 @@ class TestDocumentationNavigatorSkill:
         assert "Based on the documentation" in answer
         assert "Sources:" in answer
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_answer_question_with_conversation(self, skill):
         """Test the answer_question function with conversation context."""
         # Create a conversation
@@ -245,7 +245,7 @@ class TestDocumentationNavigatorSkill:
         assert messages[1]["type"] == "assistant"
         assert "What is the onboarding process?" in messages[0]["content"]
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_continue_conversation(self, skill):
         """Test the continue_conversation function."""
         # Create a conversation
@@ -274,7 +274,7 @@ class TestDocumentationNavigatorSkill:
         assert messages[3]["type"] == "assistant"
         assert "What should I do on my first day?" in messages[2]["content"]
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_create_conversation(self, skill):
         """Test the create_conversation function."""
         # Create a conversation
@@ -284,7 +284,7 @@ class TestDocumentationNavigatorSkill:
         assert "id" in conversation
         assert conversation["user_id"] == "test-user"
 
-    @pytest.mark.asyncio()
+    @pytest.mark.asyncio
     async def test_format_for_slack(self, skill):
         """Test the format_for_slack function."""
         # Call the function

--- a/tests/test_documentation_navigator_skill.py
+++ b/tests/test_documentation_navigator_skill.py
@@ -9,8 +9,8 @@ import asyncio  # noqa: F401
 
 # Mock the Django models and SearchService before importing DocumentationNavigatorSkill
 import sys
-from typing import Any, Dict, List  # noqa: F401, F401, F401
-from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401, F401
+from typing import Any, Dict, List  # noqa: F401
+from unittest.mock import AsyncMock, MagicMock, patch  # noqa: F401
 
 import pytest
 


### PR DESCRIPTION
Remove parentheses from pytest decorators across all test files to ensure consistency in the codebase.